### PR TITLE
Fixed add user bug

### DIFF
--- a/Chapter06/src/reducers/userlist.js
+++ b/Chapter06/src/reducers/userlist.js
@@ -25,7 +25,7 @@ export default function users(state = initialState, action) {
   switch (action.type) {
 
     case types.ADD_USER:
-      const newId = state.users[state.users.length-1] + 1;
+      const newId = state.users.length > 0 ? state.users[state.users.length - 1] + 1 : 0;
       return {
         ...state,
         users: state.users.concat(newId),


### PR DESCRIPTION
Deleting all users then trying to add more would cause a bug that would only allow you to add one user. Any additional users would just overwrite the one you've added. This is fixed by adding the proposed conditional statement on line 28.